### PR TITLE
fix: send command error message to sender instead of target

### DIFF
--- a/src/main/java/io/github/leonesoj/honey/commands/messaging/IgnoreCommand.java
+++ b/src/main/java/io/github/leonesoj/honey/commands/messaging/IgnoreCommand.java
@@ -30,7 +30,7 @@ public class IgnoreCommand {
     Player target = ctx.getArgument("player", Player.class);
 
     if (target.hasPermission("honey.management.staff")) {
-      target.sendMessage(Component.translatable("honey.settings.ignore.staff"));
+      sender.sendMessage(Component.translatable("honey.settings.ignore.staff"));
       return Command.SINGLE_SUCCESS;
     }
 


### PR DESCRIPTION
The sender, not the target, should be notified when they attempt to ignore a staff member. 