### PR TITLE
refactor: replace backend command with honey command

### DIFF
--- a/src/main/java/io/github/leonesoj/honey/HoneyBootstrap.java
+++ b/src/main/java/io/github/leonesoj/honey/HoneyBootstrap.java
@@ -21,7 +21,7 @@ import io.github.leonesoj.honey.commands.essentials.world.NetherCommand;
 import io.github.leonesoj.honey.commands.essentials.world.NightCommand;
 import io.github.leonesoj.honey.commands.essentials.world.OverworldCommand;
 import io.github.leonesoj.honey.commands.essentials.world.TheEndCommand;
-import io.github.leonesoj.honey.commands.management.BackendCommand;
+import io.github.leonesoj.honey.commands.management.HoneyCommand;
 import io.github.leonesoj.honey.commands.management.ReportsCommand;
 import io.github.leonesoj.honey.commands.messaging.ChannelCommand;
 import io.github.leonesoj.honey.commands.messaging.IgnoreCommand;
@@ -78,7 +78,7 @@ public class HoneyBootstrap implements PluginBootstrap {
       commands.registrar().register(ChannelCommand.create());
 
       /* MANAGEMENT COMMANDS */
-      commands.registrar().register(BackendCommand.create());
+      commands.registrar().register(HoneyCommand.create());
       commands.registrar().register(ReportsCommand.create());
 
       /* MODERATION COMMANDS */

--- a/src/main/java/io/github/leonesoj/honey/commands/management/HoneyCommand.java
+++ b/src/main/java/io/github/leonesoj/honey/commands/management/HoneyCommand.java
@@ -1,20 +1,20 @@
 package io.github.leonesoj.honey.commands.management;
 
+import static io.github.leonesoj.honey.locale.Message.prefixed;
+
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import io.github.leonesoj.honey.Honey;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
-import org.bukkit.entity.Player;
 
-public class BackendCommand {
+public class HoneyCommand {
 
   public static LiteralCommandNode<CommandSourceStack> create() {
-    return Commands.literal("backend")
-        .requires(stack -> stack.getSender() instanceof Player sender
-            && sender.hasPermission("honey.management.backend"))
-        .then(Commands.literal("config-reload").executes(BackendCommand::configReloadUsage))
+    return Commands.literal("honey")
+        .requires(stack -> stack.getSender().hasPermission("honey.admin"))
+        .then(Commands.literal("reload").executes(HoneyCommand::configReloadUsage))
         .build();
   }
 
@@ -24,7 +24,8 @@ public class BackendCommand {
         Honey.getInstance().config().getString("chat.channels.general.format")
     );
     Honey.getInstance().getTranslationHandler().load();
-    ctx.getSource().getSender().sendPlainMessage("Config's reloaded");
+    ctx.getSource().getSender().sendMessage(prefixed("honey.reload"));
     return Command.SINGLE_SUCCESS;
   }
+
 }

--- a/src/main/resources/translations/native/en_US.properties
+++ b/src/main/resources/translations/native/en_US.properties
@@ -5,6 +5,7 @@ honey.command.cooldown=<red>You must wait <gray><duration></gray> before perform
 honey.command.duration.invalid=Specified duration format is not valid
 honey.command.channel.invalid=Specified chat channel does not exist
 honey.command.channel.disallowed=Specified chat channel requires a higher permission level
+honey.reload=<gray>Successfully reloaded all configuration files</gray>
 honey.adventure.yourself=<gray>Set your gamemode to <light_purple>adventure</light_purple></gray>
 honey.adventure.other=<gray>Set <player>'s gamemode to <light_purple>adventure</light_purple></gray>
 honey.creative.yourself=<gray>Set your gamemode to <gold>creative</gold></gray>


### PR DESCRIPTION
Replaced /backend command with /honey because I'm planning on adding more information relevant to the plugin using /honey. And thought consolidating the reload usage would be best, and I struggled to find a use for /backend anyway.