### PR TITLE
refactor: make config load method use CompletableFuture for async handling

### DIFF
--- a/src/main/java/io/github/leonesoj/honey/config/Config.java
+++ b/src/main/java/io/github/leonesoj/honey/config/Config.java
@@ -6,6 +6,7 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.concurrent.CompletableFuture;
 import java.util.logging.Level;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -55,17 +56,23 @@ public class Config {
     // }
   }
 
-  public void loadConfig() {
+  public CompletableFuture<Void> loadConfig() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
     Bukkit.getAsyncScheduler().runNow(plugin, task -> {
       try {
-        config = YamlConfiguration.loadConfiguration(configFile);
-      } catch (IllegalArgumentException exception) {
+        YamlConfiguration cfg = new YamlConfiguration();
+        cfg.load(configFile);
+        config = cfg;
+        future.complete(null);
+      } catch (Exception exception) {
         plugin.getLogger().log(Level.SEVERE,
-            "Failed to load config file: %s.yml".formatted(configFile.getName()),
+            "Failed to load config file: %s".formatted(configFile.getName()),
             exception
         );
+        future.completeExceptionally(exception);
       }
     });
+    return future;
   }
 
   private void saveConfig() {

--- a/src/main/java/io/github/leonesoj/honey/config/ConfigHandler.java
+++ b/src/main/java/io/github/leonesoj/honey/config/ConfigHandler.java
@@ -2,6 +2,7 @@ package io.github.leonesoj.honey.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -47,8 +48,12 @@ public class ConfigHandler {
     return configs.get("staff-items").getRawConfig();
   }
 
-  public void reloadConfigs() {
-    configs.values().forEach(Config::loadConfig);
+  public CompletableFuture<Void> reloadConfigs() {
+    CompletableFuture<?>[] futures = configs.values().stream()
+        .map(Config::loadConfig)
+        .toArray(CompletableFuture[]::new);
+
+    return CompletableFuture.allOf(futures);
   }
 
 }

--- a/src/main/resources/translations/native/en_US.properties
+++ b/src/main/resources/translations/native/en_US.properties
@@ -6,6 +6,7 @@ honey.command.duration.invalid=Specified duration format is not valid
 honey.command.channel.invalid=Specified chat channel does not exist
 honey.command.channel.disallowed=Specified chat channel requires a higher permission level
 honey.reload=<gray>Successfully reloaded all configuration files</gray>
+honey.reload.failed=<red>One or more configuration files failed to reload!</red>
 honey.adventure.yourself=<gray>Set your gamemode to <light_purple>adventure</light_purple></gray>
 honey.adventure.other=<gray>Set <player>'s gamemode to <light_purple>adventure</light_purple></gray>
 honey.creative.yourself=<gray>Set your gamemode to <gold>creative</gold></gray>


### PR DESCRIPTION
Changed the loadConfig method to return a CompletableFuture for easy chaining. ConfigHandler also now handles CompletableFuture when reloading all config files.