### PR TITLE
ci: add gh actions for build/style/releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: Build Gradle and Check style
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build-gradle:
+    if: >
+      !contains(github.event.pull_request.title, '[ci skip]') &&
+      !contains(github.event.head_commit.message, '[ci skip]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Build
+        run: ./gradlew --no-daemon build
+
+      - name: Upload artifacts (only on release tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifacts
+          path: build/libs/


### PR DESCRIPTION
This PR adds a GitHub action workflow to run on every push/pull request to enforce successful builds, compliant code style, and easy release publishing. 