### PR TITLE
[ci skip] build: make run-paper auto download vault

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ tasks {
         minecraftVersion '1.21.8'
         downloadPlugins {
             modrinth ('luckperms', 'v5.5.0-bukkit')
+            github ("MilkBowl", "Vault", "1.7.3", "Vault.jar")
         }
     }
 }


### PR DESCRIPTION
Running a test server will now download Vault in addition to LuckPerms.