### PR TITLE
refactor: migrate from Vault to LuckPerms

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,14 +18,12 @@ repositories {
         url = 'https://oss.sonatype.org/content/groups/public/'
     }
     maven { url = 'https://oss.sonatype.org/content/repositories/snapshots' }
-    maven { url = 'https://jitpack.io' }
     maven { url = 'https://repo.extendedclip.com/releases/' }
 }
 
 dependencies {
     compileOnly 'io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT'
     compileOnly 'net.luckperms:api:5.4'
-    compileOnly 'com.github.MilkBowl:VaultAPI:1.7.1'
     compileOnly 'me.clip:placeholderapi:2.11.6'
     compileOnly 'io.lettuce:lettuce-core:6.5.5.RELEASE'
     compileOnly 'com.fasterxml.jackson.core:jackson-databind:2.17.0'
@@ -42,7 +40,6 @@ tasks {
         minecraftVersion '1.21.8'
         downloadPlugins {
             modrinth ('luckperms', 'v5.5.0-bukkit')
-            github ('MilkBowl', 'Vault', '1.7.3', 'Vault.jar')
         }
     }
 }

--- a/src/main/java/io/github/leonesoj/honey/chat/ChatService.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/ChatService.java
@@ -13,7 +13,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.identity.Identity;
 import net.kyori.adventure.text.Component;
-import net.milkbowl.vault.chat.Chat;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -21,7 +20,6 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
-import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class ChatService implements Listener {
 
@@ -31,13 +29,11 @@ public class ChatService implements Listener {
   private final SpyService spyService;
 
   private ChatChannel defaultChannel;
-  private Chat chat;
 
   public ChatService(SpyService spyService) {
     this.spyService = spyService;
     this.privateChatService = new PrivateChatService(spyService);
     Bukkit.getPluginManager().registerEvents(this, Honey.getInstance());
-    setupVaultChat();
   }
 
   public void registerChannel(ChatChannel chatChannel) {
@@ -215,14 +211,5 @@ public class ChatService implements Listener {
         !chatChannel.hasMember(audience) && !isSpy(audience)
     );
     event.renderer(HoneyChatRenderer.getInstance());
-  }
-
-  public Chat getVaultChat() {
-    return chat;
-  }
-
-  private void setupVaultChat() {
-    RegisteredServiceProvider<Chat> rsp = Bukkit.getServicesManager().getRegistration(Chat.class);
-    chat = rsp.getProvider();
   }
 }

--- a/src/main/java/io/github/leonesoj/honey/features/staff/StaffPermsListener.java
+++ b/src/main/java/io/github/leonesoj/honey/features/staff/StaffPermsListener.java
@@ -4,30 +4,22 @@ import io.github.leonesoj.honey.Honey;
 import io.github.leonesoj.honey.database.data.controller.StaffSettingsController;
 import io.github.leonesoj.honey.utils.other.SchedulerUtil;
 import net.luckperms.api.LuckPerms;
+import net.luckperms.api.LuckPermsProvider;
 import net.luckperms.api.event.EventBus;
 import net.luckperms.api.event.node.NodeAddEvent;
 import net.luckperms.api.event.node.NodeRemoveEvent;
 import net.luckperms.api.model.user.User;
-import org.bukkit.Bukkit;
-import org.bukkit.plugin.RegisteredServiceProvider;
 
 public class StaffPermsListener {
-
-  private LuckPerms luckPerms;
 
   private final StaffHandler handler;
 
   public StaffPermsListener(StaffHandler handler) {
-    RegisteredServiceProvider<LuckPerms> provider = Bukkit.getServicesManager()
-        .getRegistration(LuckPerms.class);
-    if (provider != null) {
-      luckPerms = provider.getProvider();
-    }
     this.handler = handler;
   }
 
   public void startListening() {
-    EventBus eventBus = luckPerms.getEventBus();
+    EventBus eventBus = LuckPermsProvider.get().getEventBus();
 
     final StaffSettingsController controller = Honey.getInstance().getDataHandler()
         .getStaffSettingsController();

--- a/src/main/java/io/github/leonesoj/honey/utils/other/DependCheck.java
+++ b/src/main/java/io/github/leonesoj/honey/utils/other/DependCheck.java
@@ -8,14 +8,6 @@ public class DependCheck {
   private DependCheck() {
   }
 
-  public static boolean isVaultInstalled() {
-    return isPluginInstalled("Vault");
-  }
-
-  public static boolean isLuckPermsInstalled() {
-    return isPluginInstalled("LuckPerms");
-  }
-
   public static boolean isProtocolLibInstalled() {
     return isPluginInstalled("ProtocolLib");
   }

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -10,9 +10,6 @@ dependencies:
   server:
     LuckPerms:
       load: BEFORE
-      required: false
-    Vault:
-      load: BEFORE
       required: true
     PlaceholderAPI:
       load: BEFORE


### PR DESCRIPTION
This PR makes LuckPerms a required dependency because Vault is very limiting in asynchronous contexts, severely outdated, and no longer maintained. As such, any offline permission checking or group metadata fetching is now done using the LuckPerms API. Considering LuckPerms is free, open-sourced, actively maintained, and abundantly capable for big and small servers, asking server owners to install and use this permissions provider shouldn't be a big ask.