### PR TITLE
refactor: organize async pipelines and cache strategies

### DIFF
--- a/src/main/java/io/github/leonesoj/honey/database/cache/CacheProvider.java
+++ b/src/main/java/io/github/leonesoj/honey/database/cache/CacheProvider.java
@@ -2,5 +2,6 @@ package io.github.leonesoj.honey.database.cache;
 
 public enum CacheProvider {
   IN_MEMORY,
-  REDIS
+  REDIS,
+  NO_OP
 }

--- a/src/main/java/io/github/leonesoj/honey/database/cache/InMemoryCache.java
+++ b/src/main/java/io/github/leonesoj/honey/database/cache/InMemoryCache.java
@@ -17,7 +17,6 @@ public class InMemoryCache extends CacheStore {
   public InMemoryCache(Logger log) {
     super(log, CacheProvider.IN_MEMORY);
     this.cache = Caffeine.newBuilder()
-        .maximumSize(250)
         .recordStats()
         .build();
 
@@ -60,7 +59,7 @@ public class InMemoryCache extends CacheStore {
 
   @Override
   public double getHitRate() {
-    return cache.stats().evictionWeight();
+    return cache.stats().hitRate();
   }
 
   @Override

--- a/src/main/java/io/github/leonesoj/honey/database/cache/NoOpCache.java
+++ b/src/main/java/io/github/leonesoj/honey/database/cache/NoOpCache.java
@@ -10,7 +10,7 @@ import java.util.function.Function;
 public class NoOpCache extends CacheStore {
 
   public NoOpCache() {
-    super(null, null);
+    super(null, CacheProvider.NO_OP);
   }
 
   @Override
@@ -21,17 +21,17 @@ public class NoOpCache extends CacheStore {
 
   @Override
   public CompletableFuture<Boolean> put(String key, DataModel value) {
-    return CompletableFuture.completedFuture(null);
+    return CompletableFuture.completedFuture(true);
   }
 
   @Override
   public CompletableFuture<Boolean> delete(String key) {
-    return CompletableFuture.completedFuture(null);
+    return CompletableFuture.completedFuture(true);
   }
 
   @Override
   public CompletableFuture<Boolean> flush(Set<String> keys) {
-    return CompletableFuture.completedFuture(null);
+    return CompletableFuture.completedFuture(true);
   }
 
   @Override

--- a/src/main/java/io/github/leonesoj/honey/database/data/controller/DataController.java
+++ b/src/main/java/io/github/leonesoj/honey/database/data/controller/DataController.java
@@ -1,79 +1,103 @@
 package io.github.leonesoj.honey.database.data.controller;
 
 import io.github.leonesoj.honey.database.DataContainer;
+import io.github.leonesoj.honey.database.cache.CacheProvider;
 import io.github.leonesoj.honey.database.cache.CacheStore;
+import io.github.leonesoj.honey.database.cache.NoOpCache;
 import io.github.leonesoj.honey.database.data.model.DataModel;
 import io.github.leonesoj.honey.database.providers.DataStore;
 import io.github.leonesoj.honey.database.record.DataRecord;
 import io.github.leonesoj.honey.observer.EventType;
 import io.github.leonesoj.honey.observer.ObserverService;
 import io.lettuce.core.json.JsonObject;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.logging.Logger;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.plugin.java.JavaPlugin;
 
-// TODO: Refactor DataStore and this class to support different indexes: i.e get, update
-
 public abstract class DataController<T extends DataModel> implements Listener {
+
+  private static final long SHARED_CACHE_TIMEOUT_MS = 100L;
 
   protected final DataStore data;
   protected final DataContainer container;
 
-  protected final CacheStore cache;
-  protected final Set<String> keysToFlush = new HashSet<>();
+  protected final CacheStore nearCache;
+  protected final CacheStore sharedCache;
+
+  protected static final CacheStore NOOP_SHARED_INSTANCE = new NoOpCache();
 
   private final Function<DataRecord, T> recordDeserializer;
   private final Function<JsonObject, T> jsonDeserializer;
 
   private final ObserverService<T> observerService;
-
   private final JavaPlugin plugin;
 
-  public DataController(DataStore data, CacheStore cache, DataContainer container,
-      Function<DataRecord, T> recordDeserializer, Function<JsonObject, T> jsonDeserializer,
-      JavaPlugin plugin, boolean enableFlush) {
+  public DataController(DataStore data,
+      DataContainer container,
+      CacheStore nearCache,
+      CacheStore sharedCache,
+      Function<DataRecord, T> recordDeserializer,
+      Function<JsonObject, T> jsonDeserializer,
+      JavaPlugin plugin) {
     this.data = data;
-    this.cache = cache;
+    this.container = container;
+    this.data.createDataStore(container);
+
+    this.nearCache = nearCache;
+    this.sharedCache = sharedCache;
 
     this.recordDeserializer = recordDeserializer;
     this.jsonDeserializer = jsonDeserializer;
 
-    this.container = container;
-    this.data.createDataStore(container);
-
-    this.plugin = plugin;
-
     this.observerService = new ObserverService<>();
-
-    if (enableFlush) {
-      scheduleCacheFlush();
-    }
+    this.plugin = plugin;
   }
 
   protected CompletableFuture<Optional<T>> get(UUID uuid, String index) {
-    return cache.get(buildKey(uuid), jsonDeserializer)
-        .exceptionally(throwable -> Optional.empty())
-        .thenCompose(cachedResult -> {
-          if (cachedResult.isPresent()) {
-            CompletableFuture<Optional<T>> future = new CompletableFuture<>();
-            future.complete(cachedResult);
-            return future;
-          }
+    final String key = buildKey(uuid);
 
-          return data.query(container, index, uuid.toString(), recordDeserializer)
-              .thenApply(optional -> {
-                optional.ifPresent(value -> cache.put(buildKey(uuid), value));
-                return optional;
-              });
-        });
+    Optional<T> nearHit = nearCache.get(key, jsonDeserializer).getNow(Optional.empty());
+    if (nearHit.isPresent()) {
+      return CompletableFuture.completedFuture(nearHit);
+    }
+
+    CompletableFuture<Optional<T>> fromShared = sharedEnabled()
+        ? sharedCache.get(key, jsonDeserializer).exceptionally(ex -> Optional.empty())
+        : CompletableFuture.completedFuture(Optional.empty());
+
+    return fromShared.thenCompose(sharedOpt -> {
+      if (sharedOpt.isPresent()) {
+        T model = sharedOpt.get();
+
+        return nearCache.put(key, model)
+            .exceptionally(ex -> true)
+            .thenApply(ok -> sharedOpt);
+      }
+
+      return data.query(container, index, uuid.toString(), recordDeserializer)
+          .thenCompose(dbOpt -> {
+            if (dbOpt.isEmpty()) {
+              return CompletableFuture.completedFuture(Optional.empty());
+            }
+            T model = dbOpt.get();
+
+            CompletableFuture<Boolean> nearPut =
+                nearCache.put(key, model).exceptionally(ex -> true);
+
+            if (sharedEnabled()) {
+              bestEffort(sharedCache.put(key, model), "shared.put-after-db:" + key);
+            }
+
+            return nearPut.thenApply(ok -> Optional.of(model));
+          });
+    });
   }
 
   protected CompletableFuture<Optional<T>> get(UUID uuid) {
@@ -85,24 +109,52 @@ public abstract class DataController<T extends DataModel> implements Listener {
   }
 
   protected CompletableFuture<Boolean> create(UUID uuid, T model) {
+    String key = buildKey(uuid);
+
     return data.insert(container, model.serialize())
-        .thenApply(result -> {
-          cache.put(buildKey(uuid), model);
-          Bukkit.getGlobalRegionScheduler().run(plugin,
-              task -> observerService.publishEvent(model, EventType.CREATE)
-          );
-          return result;
+        .thenCompose(ok -> {
+          if (!ok) {
+            return CompletableFuture.completedFuture(false);
+          }
+
+          CompletableFuture<Boolean> nearPut =
+              nearCache.put(key, model).exceptionally(ex -> true);
+
+          if (sharedEnabled()) {
+            bestEffort(sharedCache.put(key, model), "shared.put-create:" + key);
+          }
+
+          return nearPut.thenApply(result -> true);
+        })
+        .whenComplete((ok, ex) -> {
+          if (ex == null && Boolean.TRUE.equals(ok)) {
+            publishAsync(model, EventType.CREATE);
+          }
         });
   }
 
   protected CompletableFuture<Boolean> update(UUID uuid, String index, T model) {
+    String key = buildKey(uuid);
+
     return data.update(container, index, uuid, model.serialize())
-        .thenApply(result -> {
-          cache.put(buildKey(uuid), model);
-          Bukkit.getGlobalRegionScheduler().run(plugin,
-              task -> observerService.publishEvent(model, EventType.UPDATE)
-          );
-          return result;
+        .thenCompose(ok -> {
+          if (!ok) {
+            return CompletableFuture.completedFuture(false);
+          }
+
+          CompletableFuture<Boolean> nearPut =
+              nearCache.put(key, model).exceptionally(ex -> true);
+
+          if (sharedEnabled()) {
+            bestEffort(sharedCache.delete(key), "shared.invalidate-update:" + key);
+          }
+
+          return nearPut.thenApply(result -> true);
+        })
+        .whenComplete((ok, ex) -> {
+          if (ex == null && Boolean.TRUE.equals(ok)) {
+            publishAsync(model, EventType.UPDATE);
+          }
         });
   }
 
@@ -111,14 +163,49 @@ public abstract class DataController<T extends DataModel> implements Listener {
   }
 
   protected CompletableFuture<Boolean> delete(UUID uuid) {
+    String key = buildKey(uuid);
+
     return data.delete(container, container.primaryIndex(), uuid.toString())
-        .thenApply(result -> {
-          cache.delete(buildKey(uuid));
-          Bukkit.getGlobalRegionScheduler().run(plugin,
-              task -> observerService.publishEvent(null, EventType.DELETE)
-          );
-          return result;
+        .thenCompose(ok -> {
+          if (!ok) {
+            return CompletableFuture.completedFuture(false);
+          }
+
+          CompletableFuture<Boolean> nearDel =
+              nearCache.delete(key).exceptionally(ex -> true);
+
+          if (sharedEnabled()) {
+            bestEffort(sharedCache.delete(key), "shared.invalidate-delete:" + key);
+          }
+
+          return nearDel.thenApply(result -> true);
+        })
+        .whenComplete((ok, ex) -> {
+          if (ex == null && Boolean.TRUE.equals(ok)) {
+            publishAsync(null, EventType.DELETE);
+          }
         });
+  }
+
+  private <U> CompletableFuture<U> bestEffort(CompletableFuture<U> future, String what) {
+    return future.orTimeout(SHARED_CACHE_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        .exceptionally(ex -> {
+          getLogger().warning(() -> "{shared cache}[" + what + "] " + ex.getMessage());
+          return null;
+        });
+  }
+
+  protected void evictKey(UUID uuid) {
+    String key = buildKey(uuid);
+    nearCache.delete(key).exceptionally(ex -> true);
+  }
+
+  protected String buildKey(UUID uuid) {
+    return container.containerName() + ":" + uuid;
+  }
+
+  private boolean sharedEnabled() {
+    return sharedCache != null && sharedCache.getProvider() != CacheProvider.NO_OP;
   }
 
   protected <U> CompletableFuture<U> completeOnMainThread(U value) {
@@ -127,27 +214,16 @@ public abstract class DataController<T extends DataModel> implements Listener {
     return future;
   }
 
-  private void scheduleCacheFlush() {
-    Bukkit.getGlobalRegionScheduler().runAtFixedRate(
-        plugin,
-        task -> {
-          cache.flush(keysToFlush);
-          keysToFlush.clear();
-        },
-        6_000,
-        6_000
-    );
-  }
-
-  public Logger getLogger() {
-    return plugin.getLogger();
+  private void publishAsync(T model, EventType type) {
+    Bukkit.getGlobalRegionScheduler()
+        .run(plugin, task -> observerService.publishEvent(model, type));
   }
 
   public ObserverService<T> getObserverService() {
     return observerService;
   }
 
-  protected String buildKey(UUID uuid) {
-    return uuid.toString() + ":" + container.containerName();
+  public Logger getLogger() {
+    return plugin.getLogger();
   }
 }

--- a/src/main/java/io/github/leonesoj/honey/database/data/controller/ReportController.java
+++ b/src/main/java/io/github/leonesoj/honey/database/data/controller/ReportController.java
@@ -2,7 +2,6 @@ package io.github.leonesoj.honey.database.data.controller;
 
 import io.github.leonesoj.honey.Honey;
 import io.github.leonesoj.honey.database.DataContainer;
-import io.github.leonesoj.honey.database.cache.NoOpCache;
 import io.github.leonesoj.honey.database.data.model.Report;
 import io.github.leonesoj.honey.database.data.model.Report.ReportStatus;
 import io.github.leonesoj.honey.database.providers.DataStore;
@@ -18,16 +17,16 @@ public class ReportController extends DataController<Report> {
   public ReportController(DataStore data) {
     super(
         data,
-        new NoOpCache(),
         new DataContainer(Report.STORAGE_KEY,
             Report.PRIMARY_KEY,
             Report.SCHEMA,
             Report.INDEXED_FIELDS
         ),
+        NOOP_SHARED_INSTANCE,
+        NOOP_SHARED_INSTANCE,
         Report::deserialize,
         null,
-        Honey.getInstance(),
-        false
+        Honey.getInstance()
     );
     getObserverService().registerObserver(new ReportSubscriber());
   }


### PR DESCRIPTION
Refactors DataController and its inheritors because features that require data to be accessed at constant time(player/staff settings) need to utilize a specific caching strategy. Honey will now work based on this flow:
 InMemoryCache -> RedisCache/NoOpCache -> DB
But now, InMemoryCache will not have a maximum size or TTL because many features depend on data being accessed immediately. As such, InMemoryCache has to be used very carefully by enforcing tight lifecycles for its entries, or we risk causing a memory leak. RedisCache is different in the sense that the proxy/velocity will dictate when an entry should be invalidated(i.e, a staff member leaving the network rather than an individual server instance)