### PR TITLE
chore: update paper api to 1.21.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Honey - A streamlined backend for modern Minecraft servers.
 
-![](https://img.shields.io/badge/Paper%20API-1.21.8-black?style=for-the-badge&labelColor=%23D3D3D3&color=%23ffa142) ![](https://img.shields.io/badge/PRs-welcome-black?style=for-the-badge&labelColor=%23D3D3D3&color=%23ffa142) ![](https://img.shields.io/badge/License-MIT-black?style=for-the-badge&labelColor=%23D3D3D3&color=%23ffa142)
+![](https://img.shields.io/badge/Paper%20API-1.21.9-black?style=for-the-badge&labelColor=%23D3D3D3&color=%23ffa142) ![](https://img.shields.io/badge/PRs-welcome-black?style=for-the-badge&labelColor=%23D3D3D3&color=%23ffa142) ![](https://img.shields.io/badge/License-MIT-black?style=for-the-badge&labelColor=%23D3D3D3&color=%23ffa142)
 ![modrinth](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/compact/available/modrinth_vector.svg)![paper](https://cdn.jsdelivr.net/npm/@intergrav/devins-badges@3/assets/compact/supported/paper_vector.svg)
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'io.papermc.paper:paper-api:1.21.8-R0.1-SNAPSHOT'
+    compileOnly 'io.papermc.paper:paper-api:1.21.9-R0.1-SNAPSHOT'
     compileOnly 'net.luckperms:api:5.4'
     compileOnly 'me.clip:placeholderapi:2.11.6'
     compileOnly 'io.lettuce:lettuce-core:6.5.5.RELEASE'
@@ -37,7 +37,7 @@ dependencies {
 
 tasks {
     runServer {
-        minecraftVersion '1.21.8'
+        minecraftVersion '1.21.9'
         downloadPlugins {
             modrinth ('luckperms', 'v5.5.0-bukkit')
         }

--- a/src/main/resources/paper-plugin.yml
+++ b/src/main/resources/paper-plugin.yml
@@ -3,7 +3,7 @@ version: ${version}
 main: io.github.leonesoj.honey.Honey
 description: A streamlined backend for modern Minecraft servers.
 authors: [ Termxs ]
-api-version: '1.21.8'
+api-version: '1.21.9'
 loader: io.github.leonesoj.honey.HoneyLoader
 bootstrapper: io.github.leonesoj.honey.HoneyBootstrap
 dependencies:


### PR DESCRIPTION
No notable changes from the previous api version.