### PR TITLE
fix: cleanup chat mods after player quit

### DIFF
--- a/src/main/java/io/github/leonesoj/honey/chat/ChatService.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/ChatService.java
@@ -191,6 +191,7 @@ public class ChatService implements Listener {
 
   @EventHandler
   public void onLeave(PlayerQuitEvent event) {
+    chatMods.remove(event.getPlayer().getUniqueId());
     channels.values().forEach(chatChannel -> {
       if (chatChannel.hasParticipant(event.getPlayer())) {
         leaveChannel(chatChannel.getIdentifier(), event.getPlayer());


### PR DESCRIPTION
Players who were in chat mod when leaving will now be removed from the chat mods map.