### PR TITLE
feat: add chat variables to chat renderer

### DIFF
--- a/src/main/java/io/github/leonesoj/honey/chat/HoneyChatRenderer.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/HoneyChatRenderer.java
@@ -1,5 +1,11 @@
 package io.github.leonesoj.honey.chat;
 
+import io.github.leonesoj.honey.Honey;
+import io.github.leonesoj.honey.chat.variables.ItemVariable;
+import io.github.leonesoj.honey.chat.variables.LocationVariable;
+import io.github.leonesoj.honey.chat.variables.PingVariable;
+import io.github.leonesoj.honey.chat.variables.VariableRegistry;
+import io.github.leonesoj.honey.config.Config;
 import io.github.leonesoj.honey.utils.other.DependCheck;
 import java.util.Optional;
 import java.util.UUID;
@@ -26,6 +32,11 @@ public class HoneyChatRenderer {
   private static final String PREFIX_PLACEHOLDER = "prefix";
   private static final String SUFFIX_PLACEHOLDER = "suffix";
   private static final String PRIMARY_GROUP_PLACEHOLDER = "group";
+
+  private static final VariableRegistry VARIABLE_REGISTRY = new VariableRegistry()
+      .register(new ItemVariable())
+      .register(new LocationVariable())
+      .register(new PingVariable());
 
   private static final MiniMessage miniMessage = MiniMessage.miniMessage();
 
@@ -66,6 +77,13 @@ public class HoneyChatRenderer {
     String format = sourceChannel.getFormat();
     if (DependCheck.isPlaceholderApiInstalled()) {
       format = PlaceholderAPI.setPlaceholders(source, format);
+    }
+
+    Config config = Honey.getInstance().config();
+    if (config.getBoolean("chat.variables.enabled")) {
+      message = VARIABLE_REGISTRY.applyAll(message, source,
+          config.getBoolean("chat.variables.require_permission")
+      );
     }
 
     CachedMetaData metaData = LuckPermsProvider.get()

--- a/src/main/java/io/github/leonesoj/honey/chat/variables/ChatVariable.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/variables/ChatVariable.java
@@ -1,0 +1,9 @@
+package io.github.leonesoj.honey.chat.variables;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+
+public interface ChatVariable {
+  String name();
+  Component replacement(Player player);
+}

--- a/src/main/java/io/github/leonesoj/honey/chat/variables/ItemVariable.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/variables/ItemVariable.java
@@ -1,0 +1,20 @@
+package io.github.leonesoj.honey.chat.variables;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class ItemVariable implements ChatVariable {
+
+  @Override
+  public String name() {
+    return "item";
+  }
+
+  @Override
+  public Component replacement(Player player) {
+    ItemStack item = player.getInventory().getItemInMainHand();
+    return !item.isEmpty() ? item.effectiveName().hoverEvent(item.asHoverEvent())
+        : Component.empty();
+  }
+}

--- a/src/main/java/io/github/leonesoj/honey/chat/variables/LocationVariable.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/variables/LocationVariable.java
@@ -1,0 +1,23 @@
+package io.github.leonesoj.honey.chat.variables;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+public class LocationVariable implements ChatVariable {
+
+  @Override
+  public String name() {
+    return "location";
+  }
+
+  @Override
+  public Component replacement(Player player) {
+    Location loc = player.getLocation();
+    return Component.textOfChildren(
+        Component.text("x: " + loc.getBlockX() + ", "),
+        Component.text("y: " + loc.getBlockY() + ", "),
+        Component.text("z: " + loc.getBlockZ())
+    );
+  }
+}

--- a/src/main/java/io/github/leonesoj/honey/chat/variables/PingVariable.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/variables/PingVariable.java
@@ -1,0 +1,17 @@
+package io.github.leonesoj.honey.chat.variables;
+
+import net.kyori.adventure.text.Component;
+import org.bukkit.entity.Player;
+
+public class PingVariable implements ChatVariable {
+
+  @Override
+  public String name() {
+    return "ping";
+  }
+
+  @Override
+  public Component replacement(Player player) {
+    return Component.text("Ping: " + player.getPing() + "ms");
+  }
+}

--- a/src/main/java/io/github/leonesoj/honey/chat/variables/VariableRegistry.java
+++ b/src/main/java/io/github/leonesoj/honey/chat/variables/VariableRegistry.java
@@ -1,0 +1,46 @@
+package io.github.leonesoj.honey.chat.variables;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.regex.Pattern;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import org.bukkit.entity.Player;
+
+public class VariableRegistry {
+
+  private final Map<String, ChatVariable> vars = new LinkedHashMap<>();
+
+  public VariableRegistry register(ChatVariable var) {
+    vars.put(Objects.requireNonNull(var).name(), var);
+    return this;
+  }
+
+  public Component applyAll(Component input, Player player, boolean requirePermission) {
+    for (ChatVariable var : vars.values()) {
+      Component varReplacement = var.replacement(player);
+      if (varReplacement.equals(Component.empty())) {
+        continue;
+      }
+      if (requirePermission && !player.hasPermission("honey.chat.variables." + var.name())) {
+        continue;
+      }
+      Component replacement = Component.textOfChildren(
+          Component.text("[", NamedTextColor.GRAY),
+          var.replacement(player),
+          Component.text("]", NamedTextColor.GRAY)
+      );
+
+      Pattern pattern = Pattern.compile(Pattern.quote(wrap(var.name())), Pattern.CASE_INSENSITIVE);
+      input = input.replaceText(builder ->
+          builder.match(pattern).once().replacement(replacement)
+      );
+    }
+    return input;
+  }
+
+  private String wrap(String variableName) {
+    return "[" + variableName + "]";
+  }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -78,6 +78,9 @@ chat:
     format:
       command: <gray><<light_purple>#</light_purple>> <player>:</gray> <command>
       private_message: <gray><<aqua>✉</aqua>> (<player> » <recipient>):</gray> <message>
+  variables:
+    enabled: true
+    require_permission: false
 
 reports:
   # Amount of time a user must wait before submitting another successful report in seconds.


### PR DESCRIPTION
Added VariableRegistry and ChatVariable to quickly and cleanly implement chat variables within the chat renderer. This PR adds: [item] -> shows item display name and itemstack tooltips on hover, [location] -> player's current location in block coordinates, and [ping] -> player's ping to the server. With config options to enable/disable and enforce permissions to use each variable.